### PR TITLE
fixed mixed sign in FOR loops and fixed shifting of signed value

### DIFF
--- a/test/c/tweetnacl.c
+++ b/test/c/tweetnacl.c
@@ -53,7 +53,8 @@ sv ts64(u8 *x,u64 u)
 
 static int vn(const u8 *x,const u8 *y,int n)
 {
-  u32 i,d = 0;
+  int i;
+  u32 d = 0;
   FOR(i,n) d |= x[i]^y[i];
   return (1 & ((d - 1) >> 8)) - 1;
 }
@@ -278,7 +279,7 @@ sv car25519(gf o)
     o[i]+=(1LL<<16);
     c=o[i]>>16;
     o[(i+1)*(i<15)]+=c-1+37*(c-1)*(i==15);
-    o[i]-=c<<16;
+    o[i]-=(u64)c<<16;
   }
 }
 
@@ -711,7 +712,8 @@ sv reduce(u8 *r)
 int crypto_sign(u8 *sm,u64 *smlen,const u8 *m,u64 n,const u8 *sk)
 {
   u8 d[64],h[64],r[64];
-  i64 i,j,x[64];
+  u64 i;
+  i64 j,x[64];
   gf p[4];
 
   crypto_hash(d, sk, 32);
@@ -778,7 +780,7 @@ static int unpackneg(gf r[4],const u8 p[32])
 
 int crypto_sign_open(u8 *m,u64 *mlen,const u8 *sm,u64 n,const u8 *pk)
 {
-  int i;
+  unsigned int i;
   u8 t[32],h[64];
   gf p[4],q[4];
 


### PR DESCRIPTION
Changes to allow tweetnacl to compile without errors and warnings..
Fixed mismatching sign compare in FOR loops and bit shifting of signed variable.

srt/release is based of release tag 1.0.3 

# Important!

If your contribution is not trivial (not a typo fix, etc.), we can only accept
it if you dedicate your copyright for the contribution to the public domain.
Make sure you understand what it means (see http://unlicense.org/)! If you
agree, please add yourself to AUTHORS.md file, and include the following text
to your pull request description or a comment in it:

------------------------------------------------------------------------------

    I dedicate any and all copyright interest in this software to the
    public domain. I make this dedication for the benefit of the public at
    large and to the detriment of my heirs and successors. I intend this
    dedication to be an overt act of relinquishment in perpetuity of all
    present and future rights to this software under copyright law.

    Anyone is free to copy, modify, publish, use, compile, sell, or
    distribute this software, either in source code form or as a compiled
    binary, for any purpose, commercial or non-commercial, and by any
    means.
